### PR TITLE
error in binarization

### DIFF
--- a/1_MakeTrainData/GTDB_DataCreation_Unet.py
+++ b/1_MakeTrainData/GTDB_DataCreation_Unet.py
@@ -82,7 +82,7 @@ def Init_AreaType ( Area_CSV_file ):
 def sheet ( sheet_file ):
 	global scale_rate
 	# 読み込み＆白黒反転
-	page_image = np.bitwise_not( io.imread ( sheet_file, as_gray=True ) )
+	page_image = cv2.bitwise_not( cv2.imread ( sheet_file, cv2.IMREAD_GRAYSCALE ) )
 	# 縮小前に disk (radius = 1 / (2*scale)) で膨張処理 
 	page_image_tmp = dilation ( page_image, selem=disk(int(1 / (scale_rate*2))) )
 	page_image = transform.rescale ( page_image_tmp, (scale_rate, scale_rate) )


### PR DESCRIPTION
changed line 85-  
From-  page_image = np.bitwise_not( io.imread ( sheet_file, as_gray=True ) )  
To-  page_image = cv2.bitwise_not( cv2.imread ( image_path, cv2.IMREAD_GRAYSCALE ) )  
because earlier it's giving an error -ufunc 'invert' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''  
and now it matches the preprocessing done in prediction file "3_predicting/MathExtraction_Unet.py" line 56,59.