### PR TITLE
Checking for Math_symbols in the csv

### DIFF
--- a/1_MakeTrainData/GTDB_DataCreation_Unet.py
+++ b/1_MakeTrainData/GTDB_DataCreation_Unet.py
@@ -158,7 +158,7 @@ def output_images ( full_img, label_img, CharList, LineList, AreaList, output_fi
 	if any(AreaTypeDict) == False:
 		
 		for rcd in CharList :
-			if int (rcd[7]) == 1 :
+			if int (rcd[6]) == 1 :
 				block = list ( )
 				block.append( [ int( max( (int(rcd[2])-bb_margin)*scale_rate, 0.0 )),
 								int( max( (int(rcd[3])-bb_margin)*scale_rate, 0.0)),


### PR DESCRIPTION
The readme for gtdb dataset states-  
* Records starting with `Chardata` denote the characters or symbols. `1:Chardata, 2:Character ID, 3-6:Coordinates of the bounding box (left, top, right, bottom), 7:Text Mode (0:Ordinary text, 1:Math symbol), 8:Link label, 9:ID of parent character, 10:OCR code`  
earlier- if int (rcd[7]) == 1 : was checking the link label  
To check for Math_symbol it should check in 6th index  i.e. the 7th element " if int (rcd[*6*]) == 1 :"